### PR TITLE
Add Phoenix Socket support so no need to replace the Phoenix endpoint with a manually crafted cowboy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,12 +610,21 @@ Plug mode prevents `:wobserver` from starting `:cowboy` (ranch).
 Set `mode` to `:plug` in the `:wobserver` configuration to use plug mode.
 Set `remote_url_prefix` to the url prefix you put `:wobserver` behind to make sure dns node discovery still functions.
 
+
+##### cowboy
+
+Plug mode prevents `:wobserver` from starting `:cowboy` (ranch). Set `mode` to `:plug` in the `:wobserver` 
+configuration to use plug mode. Set `remote_url_prefix` to the url prefix you put `:wobserver` behind to make 
+sure dns node discovery still functions.
+
 Add the following line of code to the application's router to forward requests to `:wobserver`:
+
 ```elixir
   forward "/wobserver", to: Wobserver.Web.Router
 ```
 
 Add the following option to the `:cowboy` child_spec to enable use of the `:wobserver` websocket:
+
 ```elixir
 dispatch: [
     {:_, [
@@ -625,7 +634,22 @@ dispatch: [
   ],
 ```
 
-Example:
+##### Phoenix
+
+Add the following line of code to the Phoenix router to forward requests to `:wobserver`:
+
+```elixir
+  forward "/wobserver", Wobserver.Web.Router
+```
+
+Add the following option to your Phoenix applications Endpoint to enable use of the `:wobserver` websocket (the 
+path should match what is in the 'forward' in your router):
+
+```elixir
+  socket "/wobserver", Wobserver.Web.PhoenixSocket
+```
+
+##### Cowboy Example
 
 __config.exs__
 ```elixir

--- a/coveralls.json
+++ b/coveralls.json
@@ -5,6 +5,7 @@
     "lib/wobserver/web/client.ex", // For now...
     "lib/wobserver/web/client_socket.ex",
     "lib/wobserver/web/client_proxy.ex",
+    "lib/wobserver/web/phoenix_socket.ex",
     "lib/wobserver/web/router/static.ex"
   ],
   "coverage_options": {

--- a/lib/wobserver/web/phoenix_socket.ex
+++ b/lib/wobserver/web/phoenix_socket.ex
@@ -1,0 +1,28 @@
+defmodule Wobserver.Web.PhoenixSocket do
+  @moduledoc """
+  Drop-in Phoenix Socket for easier integration in to Phoenix endpoints
+
+  Example:
+    ```elixir
+    defmodule MyPhoenixServer.Endpoint do
+      socket "/wobserver", Wobserver.Web.PhoenixSocket # The path should be the same as the router path
+
+      ...
+    end
+    ```
+  """
+
+  @doc false
+  def __transports__ do
+    config = [
+      cowboy: Wobserver.Web.Client
+    ]
+    callback_module = Wobserver.Web.PhoenixSocket
+    transport_path = :ws
+    websocket_socket = {transport_path, {callback_module, config}}
+    # Only handling one type, websocket, no longpolling or anything else
+    [
+      websocket_socket
+    ]
+  end
+end


### PR DESCRIPTION
Currently to add wobserver to a Phoenix project requires tearing the cowboy setup out of phoenix when phoenix already has a way to inject websockets (and longpolling and others) significantly more easily.

This PR adds a new `Wobserver.Web.PhoenixSocket` file that implements the single callback needed for Phoenix to know what-it-is, this now allows Wobserver's websocket to be added to a normal phoenix endpoint by just doing:
```elixir
  socket "/wobserver", Wobserver.Web.PhoenixSocket
```

I did consider adding the single callback to the client_socket.ex or the client.ex files, however I figured that was mixing concerns a bit too much, however if you want to do that then all that is needed is to copy the single callback function from inside `Wobserver.Web.PhoenixSocket` to whichever file and make the appropriate changes if any, then they can just use `socket "/wobserver", Wobserver.Web.Client` line straight if you so wish.  :-)

This PR also adds a section in the Plug section in the README.md that documents this use.

This PR does not add any form of dependency on Phoenix at all, Phoenix is abstracted out in such a way that that is rarely necessary, especially with its cowboy integration sections.