### PR TITLE
Mms/https viewing fixes

### DIFF
--- a/lib/wobserver/web/router/static.ex
+++ b/lib/wobserver/web/router/static.ex
@@ -21,7 +21,7 @@ defmodule Wobserver.Web.Router.Static do
         |> send_asset("assets/index.html", &Assets.html/0);
       false ->
         conn
-        |> put_resp_header("location", conn.request_path <> "/")
+        |> put_resp_header("location", "./wobserver/")
         |> resp(301, "Redirecting to Wobserver.")
     end
   end

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -19,7 +19,7 @@
     <script src="//code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/raphael/2.2.7/raphael.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/treant-js/1.0/Treant.min.js"></script>
-    <script src="//www.chartjs.org/assets/Chart.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js"></script>
 
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="main.css">

--- a/src/js/wobserver_client.js
+++ b/src/js/wobserver_client.js
@@ -9,10 +9,14 @@ class WobserverClient {
     this.state = 0;
   }
 
+  wsProtocol() {
+    return location.protocol === 'https:' ? 'wss://' : 'ws://';
+  }
+
   connect(node_change, fallback_callback, connected_callback) {
     this.node_change = node_change;
 
-    this.socket = new WebSocket('ws://' + this.host + '/ws');
+    this.socket = new WebSocket(this.wsProtocol() + this.host + '/ws');
 
     this.socket.onerror = (error) => {
       if( this.socket.readyState == 3 ){
@@ -49,7 +53,7 @@ class WobserverClient {
   }
 
   reconnect() {
-    let new_socket = new WebSocket('ws://' + this.host + '/ws');
+    let new_socket = new WebSocket(this.wsProtocol() + this.host + '/ws');
 
     new_socket.onerror = (error) => {
       if( this.socket.readyState == 3 ){


### PR DESCRIPTION
This PR does the following:

1. Host Chart.min.js on cloudflare like the rest of the scripts so that the graphs will load over https.
2. Use secure websockets (wss) protocol if page is served over https.
3. Fix trailing slash redirect so that it is completely relative to the current path.

These are necessary for my use cases, and they seem like they might be useful for others too! Should fix https://github.com/shinyscorpion/wobserver/issues/25.