### PR TITLE
Allow credentials to be passed up to allow securing behind phoenix pipelines

### DIFF
--- a/src/js/wobserver_api_fallback.js
+++ b/src/js/wobserver_api_fallback.js
@@ -14,11 +14,11 @@ class WobserverApiFallback {
   }
 
   command(command, data = null) {
-    fetch(build_url(this.host, command, this.node))
+    fetch(build_url(this.host, command, this.node), { credentials: 'same-origin' })
   }
 
   command_promise(command, data = null) {
-    return fetch(build_url(this.host, command, this.node))
+    return fetch(build_url(this.host, command, this.node), { credentials: 'same-origin' })
     .then(res => res.json())
     .then(data => { return {
       data: data,


### PR DESCRIPTION
The following does not work:

```elixir
scope "/admin" do
  pipe_through :admin

  forward "/wobserver", Wobserver.Web.Router
end
```

All JSON api requests end up being denied because no cookies are sent and so therefore cannot be validated.