### PR TITLE
Fix websocket_client version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -74,7 +74,7 @@ defmodule Wobserver.Mixfile do
       {:meck, "~> 0.8.4", only: :test},
       {:plug, "~> 1.3 or ~> 1.4"},
       {:poison, "~> 2.0 or ~> 3.1"},
-      {:websocket_client, "~> 1.2"},
+      {:websocket_client, "~> 1.3.0"},
     ]
   end
 end


### PR DESCRIPTION
Currently last version(1.4+) of websocket_client cannot compile with rebar3.

This issue was reproduced in three different environments

** (Mix) Could not compile dependency :websocket_client, "/home/gabriel/.asdf/installs/elixir/1.5.2/.mix/rebar3 bare compile --paths "/home/gabriel/workspace/iexikos/_build/dev/lib/*/ebin"" command failed. You can recompile this dependency with "mix deps.compile websocket_client", update it with "mix deps.update websocket_client" or clean it with "mix deps.clean websocket_client"
